### PR TITLE
Use String.make to make 72 NUL string

### DIFF
--- a/lib/gpt.ml
+++ b/lib/gpt.ml
@@ -26,7 +26,7 @@ module Partition = struct
     name : string; (*name should be encoded as a utf-16 string of 72 bytes*)
   }
 
-  let make ?(name =  String.of_bytes(Bytes.create 72)) ~type_guid ~attributes starting_lba ending_lba =
+  let make ?(name =  String.make 72 '\000') ~type_guid ~attributes starting_lba ending_lba =
     match Uuidm.of_string type_guid with
     | None -> Error (Printf.sprintf "Invalid type_guid: not a valid UUID\n%!")
     | Some guid ->


### PR DESCRIPTION
`Bytes.create` (and `String.create`= returns a bytes (string) with _uninitialized_ data. Instead we wan it initialized with zero bytes.

With your commit and this small change #1 is fixed.